### PR TITLE
Twiddle pyproject.toml license specification to reduce deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "numpy>=1.19.3",
-    "setuptools>=80",
+    "setuptools>=60",
     "setuptools_scm[simple]>=8",
     "wheel",
 ]
@@ -12,7 +12,7 @@ name = "ar"
 dynamic = ["version"]
 description = "Autoregressive process modeling tools"
 readme = {file = "README.rst", content-type = "text/x-rst"}
-license = {file = "LICENSE", content-type = "text/plain"}
+license = {text = "MPL-2.0"}
 requires-python = ">=3.7"
 authors = [
     {name = "Rhys Ulerich", email = "rhys.ulerich@gmail.com"}


### PR DESCRIPTION
Update license field to use {text = "MPL-2.0"} format and lower setuptools requirement to >=60 to support Python 3.7 and 3.8.

Background:
- setuptools 70.0.0 dropped Python 3.7 support
- setuptools 76.0.0 dropped Python 3.8 support
- setuptools 77.0.0 introduced SPDX string format (license = "MPL-2.0")
- Previous requirement of setuptools>=80 was incompatible with Python 3.7/3.8

The SPDX string format is only available in setuptools>=77, which doesn't support Python 3.7/3.8. This fix uses the {text = "..."} table format which works across all setuptools versions (60+).

Note: setuptools>=77 will still show a deprecation warning for the table format, but this is unavoidable while maintaining Python 3.7/3.8 support. The {text = "..."} format is preferred over {file = "..."} as it directly specifies the license identifier.

Fixes #41