### PR TITLE
`arsel -v` now includes CXXFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ar6.o:   ar6.cpp   ar.hpp
 ar6:     ar6.o
 
 arsel.o:   arsel.cpp   ar.hpp
-	$(CXX) $(CXXFLAGS) -DARSEL_VERSION='"$(VERSION)"' -c -o arsel.o arsel.cpp
+	$(CXX) $(CXXFLAGS) -DARSEL_VERSION='"$(VERSION)"' -DARSEL_CXXFLAGS='"$(CXXFLAGS)"' -c -o arsel.o arsel.cpp
 
 arsel:     arsel.o
 

--- a/arsel.cpp
+++ b/arsel.cpp
@@ -30,6 +30,10 @@
 #define ARSEL_VERSION "unspecified"
 #endif
 
+#ifndef ARSEL_CXXFLAGS
+#define ARSEL_CXXFLAGS "unspecified"
+#endif
+
 // Forward declarations for argument checking logic
 struct Arg : public option::Arg
 {
@@ -100,7 +104,8 @@ int main(int argc, char *argv[])
         }
 
         if (options[VERSION]) {
-            cout << "arsel " << ARSEL_VERSION << "\n";
+            cout << "arsel version " << ARSEL_VERSION
+                 << " compiled with " << ARSEL_CXXFLAGS << "\n";
             return EXIT_SUCCESS;
         }
 


### PR DESCRIPTION
Modified arsel -v to output both version and CXXFLAGS from compilation.

Output is now "arsel version <VERSION> compiled with <CXXFLAGS>".

When defines are not provided, both default to "unspecified" using #ifndef guards.