### PR TITLE
Remove Python 3.7 and 3.8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,6 @@ workflows:
           matrix:
             parameters:
               version-python:
-                - "3.7"
-                - "3.8"
                 - "3.9"
                 - "3.10"
                 - "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "numpy>=1.19.3",
-    "setuptools>=60",
+    "setuptools>=65",
     "setuptools_scm[simple]>=8",
     "wheel",
 ]
@@ -12,16 +12,14 @@ name = "ar"
 dynamic = ["version"]
 description = "Autoregressive process modeling tools"
 readme = {file = "README.rst", content-type = "text/x-rst"}
-license = {text = "MPL-2.0"}
-requires-python = ">=3.7"
+license = "MPL-2.0"
+requires-python = ">=3.9"
 authors = [
     {name = "Rhys Ulerich", email = "rhys.ulerich@gmail.com"}
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
- Update minimum Python version to 3.9
- Remove Python 3.7 and 3.8 from classifiers and CI test matrix
- Use clean SPDX license identifier (MPL-2.0) instead of {text = "..."}
- Bump minimum setuptools version to 65