### PR TITLE
Update copyright headers to latest modification years

### DIFF
--- a/ar-python.cpp
+++ b/ar-python.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2026 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ar.hpp
+++ b/ar.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2026 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/ar6.cpp
+++ b/ar6.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2018 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/arsel.cpp
+++ b/arsel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2026 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/lorenz.cpp
+++ b/lorenz.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2012, 2013 Rhys Ulerich
+// Copyright (C) 2012, 2013, 2014 Rhys Ulerich
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Updated copyright years in source files to include the year of their last modification:

- ar.hpp, ar-python.cpp, arsel.cpp: Added 2026
- lorenz.cpp: Added 2014
- ar6.cpp: Added 2018

This ensures copyright notices accurately reflect the years in which each file was last modified.